### PR TITLE
fix: 빌드 실패 시 에러 메세지 ERROR줄만 출력

### DIFF
--- a/app/analyzer/build_analyzer.py
+++ b/app/analyzer/build_analyzer.py
@@ -87,6 +87,9 @@ def build_and_analyze(dockerfile_content: str, tag: str | None = None) -> BuildR
                 error_message=None
             )
         else:
+            #ERROR 포함된 줄만 뽑기
+            error_lines = [line for line  in result.stderr.splitlines() if "ERROR" in line]
+            error_message = "\n".join(error_lines) if error_lines else result.stderr #에러 줄 없으면 전체 출력
             return BuildResult(
                 success=False,
                 build_time_seconds=build_time,
@@ -94,5 +97,5 @@ def build_and_analyze(dockerfile_content: str, tag: str | None = None) -> BuildR
                 image_id=None,
                 tag=tag,
                 base_images=base_images,
-                error_message=result.stderr
+                error_message=error_message
             )

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -32,11 +32,16 @@
 #
 #CMD ["node", "dist/app.js"]
 
-FROM node:latest AS builder
-RUN echo "building..."
 
-FROM python:3.11-slim AS tester
-RUN echo "testing..."
+#FROM node:latest AS builder
+#RUN echo "building..."
 
-FROM node:20-slim
-CMD ["node", "--version"]
+#FROM python:3.11-slim AS tester
+#RUN echo "testing..."
+
+#FROM node:20-slim
+#CMD ["node", "--version"]
+
+FROM python:3.11-slim
+RUN pip install 존재하지않는패키지
+CMD ["python", "--version"]


### PR DESCRIPTION
✍🏻 Description
빌드 실패 시 에러 메시지가 너무 길게 출력되는 문제를 개선

🛠️ Changes
* stderr 전체 대신 ERROR 포함된 줄만 추출
* ERROR 줄 없으면 전체 출력하는 안전장치 추가

📸 Result
<img width="653" height="133" alt="스크린샷 2026-04-04 오전 10 26 23" src="https://github.com/user-attachments/assets/0b1df72e-d27a-4d0f-9a76-cd5fd277dd2d" />


🔗 Issue
* close #34