### PR TITLE
Feat/#44/trivy inter

### DIFF
--- a/app/analyzer/build_analyzer.py
+++ b/app/analyzer/build_analyzer.py
@@ -9,6 +9,8 @@ import tarfile
 from datetime import datetime
 from dataclasses import dataclass
 
+from app.analyzer.static_analyzer import parse_dockerfile
+
 @dataclass
 class BuildResult:
     success: bool
@@ -166,9 +168,12 @@ def build_and_analyze(dockerfile_content: str, tag: str | None = None) -> BuildR
     #FROM 라인에서 base image 추출
     base_images = []
     stage = 1
-    for line in dockerfile_content.splitlines():
-        if line.strip().startswith("FROM"):  #FROM으로 시작하는 줄 찾기
-            image = line.split()[1]
+    for instruction in parse_dockerfile(dockerfile_content):
+        if instruction.name == "FROM":
+            parts = instruction.value.split()
+            image = next((part for part in parts if not part.startswith("--")), None)
+            if image is None:
+                continue
             base_images.append(f"stage{stage}: {image}")  # 스테이지 번호와 함께 추가
             stage += 1
     if tag and not validate_tag(tag):  # 태그가 있으면 유효성 검사

--- a/app/analyzer/security_analyzer.py
+++ b/app/analyzer/security_analyzer.py
@@ -1,0 +1,127 @@
+import json
+import shutil
+import subprocess
+from dataclasses import dataclass
+
+
+_SEVERITIES = ("CRITICAL", "HIGH", "MEDIUM", "LOW", "UNKNOWN")
+
+
+@dataclass
+class SecuritySummary:
+    scanner: str
+    target: str
+    total_findings: int
+    severity_counts: dict[str, int]
+
+
+@dataclass
+class SecurityScanResult:
+    success: bool
+    mode: str
+    target: str
+    summary: SecuritySummary | None
+    error_message: str | None
+
+
+def _empty_counts() -> dict[str, int]:
+    return {severity: 0 for severity in _SEVERITIES}
+
+
+def _merge_count(
+    counts: dict[str, int],
+    severity: str | None,
+    amount: int = 1,
+) -> None:
+    key = (severity or "UNKNOWN").upper()
+    if key not in counts:
+        key = "UNKNOWN"
+    counts[key] += amount
+
+
+def _parse_results(results: list[dict]) -> tuple[int, dict[str, int]]:
+    total = 0
+    counts = _empty_counts()
+
+    for result in results:
+        for vulnerability in result.get("Vulnerabilities") or []:
+            total += 1
+            _merge_count(counts, vulnerability.get("Severity"))
+
+        misconfig_summary = result.get("MisconfSummary") or {}
+        misconfig_total = (
+            misconfig_summary.get("CriticalCount", 0)
+            + misconfig_summary.get("HighCount", 0)
+            + misconfig_summary.get("MediumCount", 0)
+            + misconfig_summary.get("LowCount", 0)
+        )
+        if misconfig_total:
+            total += misconfig_total
+            _merge_count(counts, "CRITICAL", misconfig_summary.get("CriticalCount", 0))
+            _merge_count(counts, "HIGH", misconfig_summary.get("HighCount", 0))
+            _merge_count(counts, "MEDIUM", misconfig_summary.get("MediumCount", 0))
+            _merge_count(counts, "LOW", misconfig_summary.get("LowCount", 0))
+
+        for secret in result.get("Secrets") or []:
+            total += 1
+            _merge_count(counts, secret.get("Severity"))
+
+    return total, counts
+
+
+def _scan(command: list[str], mode: str, target: str) -> SecurityScanResult:
+    if shutil.which("trivy") is None:
+        return SecurityScanResult(
+            success=False,
+            mode=mode,
+            target=target,
+            summary=None,
+            error_message="Trivy가 설치되어 있지 않습니다. `trivy --version`으로 설치 여부를 확인하세요.",
+        )
+
+    result = subprocess.run(command, capture_output=True, text=True)
+    if result.returncode != 0:
+        error_message = result.stderr.strip() or result.stdout.strip() or "Trivy 실행에 실패했습니다."
+        return SecurityScanResult(
+            success=False,
+            mode=mode,
+            target=target,
+            summary=None,
+            error_message=error_message,
+        )
+
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return SecurityScanResult(
+            success=False,
+            mode=mode,
+            target=target,
+            summary=None,
+            error_message="Trivy JSON 결과를 파싱하지 못했습니다.",
+        )
+
+    total, counts = _parse_results(payload.get("Results") or [])
+    summary = SecuritySummary(
+        scanner=mode,
+        target=payload.get("ArtifactName") or target,
+        total_findings=total,
+        severity_counts=counts,
+    )
+    return SecurityScanResult(
+        success=True,
+        mode=mode,
+        target=target,
+        summary=summary,
+        error_message=None,
+    )
+
+
+def scan_config(file_path: str) -> SecurityScanResult:
+    command = ["trivy", "config", "--format", "json", "--quiet", file_path]
+    return _scan(command, mode="config", target=file_path)
+
+
+def scan_image(image_ref: str) -> SecurityScanResult:
+    command = ["trivy", "image", "--format", "json", "--quiet", image_ref]
+    return _scan(command, mode="image", target=image_ref)

--- a/app/analyzer/security_analyzer.py
+++ b/app/analyzer/security_analyzer.py
@@ -1,7 +1,9 @@
 import json
+import platform
 import shutil
 import subprocess
 from dataclasses import dataclass
+from pathlib import Path
 
 
 _SEVERITIES = ("CRITICAL", "HIGH", "MEDIUM", "LOW", "UNKNOWN")
@@ -28,6 +30,35 @@ def _empty_counts() -> dict[str, int]:
     return {severity: 0 for severity in _SEVERITIES}
 
 
+def _install_guide() -> str:
+    system = platform.system().lower()
+
+    if system == "windows":
+        return (
+            "Trivy가 설치되어 있지 않습니다.\n"
+            "Windows에서는 아래 방법 중 하나로 설치하세요.\n"
+            "- winget install AquaSecurity.Trivy\n"
+            "- choco install trivy\n"
+            "설치 후 `trivy --version`으로 확인하세요.\n"
+            "공식 문서: https://trivy.dev/docs/latest/getting-started/installation/"
+        )
+
+    if system == "darwin":
+        return (
+            "Trivy가 설치되어 있지 않습니다.\n"
+            "macOS에서는 `brew install trivy`로 설치할 수 있습니다.\n"
+            "설치 후 `trivy --version`으로 확인하세요.\n"
+            "공식 문서: https://trivy.dev/docs/latest/getting-started/installation/"
+        )
+
+    return (
+        "Trivy가 설치되어 있지 않습니다.\n"
+        "Linux에서는 배포판에 맞는 패키지 매니저 또는 바이너리 설치를 사용하세요.\n"
+        "설치 후 `trivy --version`으로 확인하세요.\n"
+        "공식 문서: https://trivy.dev/docs/latest/getting-started/installation/"
+    )
+
+
 def _merge_count(
     counts: dict[str, int],
     severity: str | None,
@@ -48,19 +79,28 @@ def _parse_results(results: list[dict]) -> tuple[int, dict[str, int]]:
             total += 1
             _merge_count(counts, vulnerability.get("Severity"))
 
-        misconfig_summary = result.get("MisconfSummary") or {}
-        misconfig_total = (
-            misconfig_summary.get("CriticalCount", 0)
-            + misconfig_summary.get("HighCount", 0)
-            + misconfig_summary.get("MediumCount", 0)
-            + misconfig_summary.get("LowCount", 0)
-        )
-        if misconfig_total:
-            total += misconfig_total
-            _merge_count(counts, "CRITICAL", misconfig_summary.get("CriticalCount", 0))
-            _merge_count(counts, "HIGH", misconfig_summary.get("HighCount", 0))
-            _merge_count(counts, "MEDIUM", misconfig_summary.get("MediumCount", 0))
-            _merge_count(counts, "LOW", misconfig_summary.get("LowCount", 0))
+        misconfigurations = result.get("Misconfigurations") or []
+        if misconfigurations:
+            for misconfiguration in misconfigurations:
+                status = (misconfiguration.get("Status") or "").upper()
+                if status and status not in {"FAIL", "FAILED"}:
+                    continue
+                total += 1
+                _merge_count(counts, misconfiguration.get("Severity"))
+        else:
+            misconfig_summary = result.get("MisconfSummary") or {}
+            misconfig_total = (
+                misconfig_summary.get("CriticalCount", 0)
+                + misconfig_summary.get("HighCount", 0)
+                + misconfig_summary.get("MediumCount", 0)
+                + misconfig_summary.get("LowCount", 0)
+            )
+            if misconfig_total:
+                total += misconfig_total
+                _merge_count(counts, "CRITICAL", misconfig_summary.get("CriticalCount", 0))
+                _merge_count(counts, "HIGH", misconfig_summary.get("HighCount", 0))
+                _merge_count(counts, "MEDIUM", misconfig_summary.get("MediumCount", 0))
+                _merge_count(counts, "LOW", misconfig_summary.get("LowCount", 0))
 
         for secret in result.get("Secrets") or []:
             total += 1
@@ -76,7 +116,7 @@ def _scan(command: list[str], mode: str, target: str) -> SecurityScanResult:
             mode=mode,
             target=target,
             summary=None,
-            error_message="Trivy가 설치되어 있지 않습니다. `trivy --version`으로 설치 여부를 확인하세요.",
+            error_message=_install_guide(),
         )
 
     result = subprocess.run(command, capture_output=True, text=True)
@@ -104,7 +144,7 @@ def _scan(command: list[str], mode: str, target: str) -> SecurityScanResult:
     total, counts = _parse_results(payload.get("Results") or [])
     summary = SecuritySummary(
         scanner=mode,
-        target=payload.get("ArtifactName") or target,
+        target=target,
         total_findings=total,
         severity_counts=counts,
     )
@@ -118,10 +158,32 @@ def _scan(command: list[str], mode: str, target: str) -> SecurityScanResult:
 
 
 def scan_config(file_path: str) -> SecurityScanResult:
-    command = ["trivy", "config", "--format", "json", "--quiet", file_path]
+    path = Path(file_path)
+    scan_target = str(path.parent if path.is_file() else path)
+    command = [
+        "trivy",
+        "config",
+        "--format",
+        "json",
+        "--quiet",
+        "--misconfig-scanners",
+        "dockerfile",
+        scan_target,
+    ]
     return _scan(command, mode="config", target=file_path)
 
 
 def scan_image(image_ref: str) -> SecurityScanResult:
-    command = ["trivy", "image", "--format", "json", "--quiet", image_ref]
+    command = [
+        "trivy",
+        "image",
+        "--format",
+        "json",
+        "--quiet",
+        "--scanners",
+        "vuln,secret",
+        "--image-config-scanners",
+        "misconfig,secret",
+        image_ref,
+    ]
     return _scan(command, mode="image", target=image_ref)

--- a/app/analyzer/security_analyzer.py
+++ b/app/analyzer/security_analyzer.py
@@ -15,6 +15,17 @@ class SecuritySummary:
     target: str
     total_findings: int
     severity_counts: dict[str, int]
+    findings: list["SecurityFinding"]
+
+
+@dataclass
+class SecurityFinding:
+    category: str
+    severity: str
+    title: str
+    identifier: str | None
+    target: str | None
+    detail: str | None
 
 
 @dataclass
@@ -70,14 +81,48 @@ def _merge_count(
     counts[key] += amount
 
 
-def _parse_results(results: list[dict]) -> tuple[int, dict[str, int]]:
+def _summarize_text(value: str | None, limit: int = 140) -> str | None:
+    if not value:
+        return None
+    clean = " ".join(str(value).split())
+    if len(clean) <= limit:
+        return clean
+    return clean[: limit - 3] + "..."
+
+
+def _parse_results(results: list[dict]) -> tuple[int, dict[str, int], list[SecurityFinding]]:
     total = 0
     counts = _empty_counts()
+    findings: list[SecurityFinding] = []
 
     for result in results:
         for vulnerability in result.get("Vulnerabilities") or []:
             total += 1
-            _merge_count(counts, vulnerability.get("Severity"))
+            severity = vulnerability.get("Severity")
+            _merge_count(counts, severity)
+            findings.append(
+                SecurityFinding(
+                    category="vulnerability",
+                    severity=(severity or "UNKNOWN").upper(),
+                    title=vulnerability.get("Title")
+                    or vulnerability.get("PkgName")
+                    or "취약점",
+                    identifier=vulnerability.get("VulnerabilityID"),
+                    target=vulnerability.get("PkgName"),
+                    detail=_summarize_text(
+                        " / ".join(
+                            part
+                            for part in [
+                                vulnerability.get("InstalledVersion"),
+                                f"fixed: {vulnerability.get('FixedVersion')}"
+                                if vulnerability.get("FixedVersion")
+                                else None,
+                            ]
+                            if part
+                        )
+                    ),
+                )
+            )
 
         misconfigurations = result.get("Misconfigurations") or []
         if misconfigurations:
@@ -86,7 +131,26 @@ def _parse_results(results: list[dict]) -> tuple[int, dict[str, int]]:
                 if status and status not in {"FAIL", "FAILED"}:
                     continue
                 total += 1
-                _merge_count(counts, misconfiguration.get("Severity"))
+                severity = misconfiguration.get("Severity")
+                _merge_count(counts, severity)
+                findings.append(
+                    SecurityFinding(
+                        category="misconfig",
+                        severity=(severity or "UNKNOWN").upper(),
+                        title=misconfiguration.get("Title")
+                        or misconfiguration.get("Message")
+                        or "Misconfiguration",
+                        identifier=misconfiguration.get("ID")
+                        or misconfiguration.get("AVDID"),
+                        target=misconfiguration.get("Type")
+                        or result.get("Target"),
+                        detail=_summarize_text(
+                            misconfiguration.get("Description")
+                            or misconfiguration.get("Resolution")
+                            or misconfiguration.get("Message")
+                        ),
+                    )
+                )
         else:
             misconfig_summary = result.get("MisconfSummary") or {}
             misconfig_total = (
@@ -104,12 +168,32 @@ def _parse_results(results: list[dict]) -> tuple[int, dict[str, int]]:
 
         for secret in result.get("Secrets") or []:
             total += 1
-            _merge_count(counts, secret.get("Severity"))
+            severity = secret.get("Severity")
+            _merge_count(counts, severity)
+            findings.append(
+                SecurityFinding(
+                    category="secret",
+                    severity=(severity or "UNKNOWN").upper(),
+                    title=secret.get("Title")
+                    or secret.get("RuleID")
+                    or "Secret",
+                    identifier=secret.get("RuleID"),
+                    target=secret.get("Target")
+                    or secret.get("File")
+                    or result.get("Target"),
+                    detail=_summarize_text(secret.get("Match") or secret.get("Category")),
+                )
+            )
 
-    return total, counts
+    return total, counts, findings
 
 
-def _scan(command: list[str], mode: str, target: str) -> SecurityScanResult:
+def _scan(
+    command: list[str],
+    mode: str,
+    target: str,
+    result_target_name: str | None = None,
+) -> SecurityScanResult:
     if shutil.which("trivy") is None:
         return SecurityScanResult(
             success=False,
@@ -141,12 +225,21 @@ def _scan(command: list[str], mode: str, target: str) -> SecurityScanResult:
             error_message="Trivy JSON 결과를 파싱하지 못했습니다.",
         )
 
-    total, counts = _parse_results(payload.get("Results") or [])
+    results = payload.get("Results") or []
+    if result_target_name is not None:
+        results = [
+            result
+            for result in results
+            if Path(result.get("Target") or "").name == result_target_name
+        ]
+
+    total, counts, findings = _parse_results(results)
     summary = SecuritySummary(
         scanner=mode,
         target=target,
         total_findings=total,
         severity_counts=counts,
+        findings=findings,
     )
     return SecurityScanResult(
         success=True,
@@ -170,7 +263,12 @@ def scan_config(file_path: str) -> SecurityScanResult:
         "dockerfile",
         scan_target,
     ]
-    return _scan(command, mode="config", target=file_path)
+    return _scan(
+        command,
+        mode="config",
+        target=file_path,
+        result_target_name=path.name if path.is_file() else None,
+    )
 
 
 def scan_image(image_ref: str) -> SecurityScanResult:

--- a/app/reporter/console.py
+++ b/app/reporter/console.py
@@ -13,6 +13,13 @@ console = Console()
 
 _SEVERITY_COLOR = {"high": "red", "medium": "yellow"}
 _GRADE_COLOR = {"Good": "green", "Warning": "yellow", "Risky": "red"}
+_SECURITY_SEVERITY_COLOR = {
+    "CRITICAL": "red",
+    "HIGH": "red",
+    "MEDIUM": "yellow",
+    "LOW": "cyan",
+    "UNKNOWN": "white",
+}
 
 
 def _format_base_images(base_images: list[str], fallback: str) -> str:
@@ -24,6 +31,30 @@ def _format_base_images(base_images: list[str], fallback: str) -> str:
         f"stage{index}: {image}"
         for index, image in enumerate(base_images, start=1)
     )
+
+
+def _format_security_findings(security_result: SecurityScanResult) -> str:
+    summary = security_result.summary
+    if summary is None or not summary.findings:
+        return ""
+
+    lines = []
+    for finding in summary.findings[:10]:
+        color = _SECURITY_SEVERITY_COLOR.get(finding.severity, "white")
+        identifier = f" ({finding.identifier})" if finding.identifier else ""
+        target = f" [{finding.target}]" if finding.target else ""
+        lines.append(
+            f"[{color}][bold]{finding.severity}[/bold][/{color}] "
+            f"{finding.category}{identifier}: {finding.title}{target}"
+        )
+        if finding.detail:
+            lines.append(f"  {finding.detail}")
+
+    remaining = len(summary.findings) - 10
+    if remaining > 0:
+        lines.append(f"... 외 {remaining}건")
+
+    return "\n".join(lines)
 
 
 def print_compare(
@@ -153,6 +184,14 @@ def print_report(
                 f"{security_result.error_message or ''}"
             )
         console.print(Panel(security_text, title="[bold cyan]🛡️ Trivy 결과[/bold cyan]", expand=True))
+        if security_result.success and security_result.summary is not None and security_result.summary.findings:
+            console.print(
+                Panel(
+                    _format_security_findings(security_result),
+                    title="[bold cyan]🔎 Trivy 상세 결과[/bold cyan]",
+                    expand=True,
+                )
+            )
 
     # ── 최종 점수 ────────────────────────────────────────────────
     grade_color = _GRADE_COLOR.get(score_result.grade, "white")

--- a/app/reporter/console.py
+++ b/app/reporter/console.py
@@ -6,6 +6,7 @@ from rich.text import Text
 
 from app.analyzer.static_analyzer import StaticAnalysisResult
 from app.analyzer.build_analyzer import BuildResult
+from app.analyzer.security_analyzer import SecurityScanResult
 from app.scorer.calculator import ScoreResult
 
 console = Console()
@@ -29,17 +30,19 @@ def print_compare(
     static_b: StaticAnalysisResult,
     score_b: ScoreResult,
     build_result_b: BuildResult | None,
+    security_result_b: SecurityScanResult | None,
     static_a: StaticAnalysisResult,
     score_a: ScoreResult,
     build_result_a: BuildResult | None,
+    security_result_a: SecurityScanResult | None,
     before_path: str,
     after_path: str,
 ) -> None:
     console.rule("[bold yellow]◀  BEFORE[/bold yellow]")
-    print_report(static_b, score_b, build_result_b, before_path)
+    print_report(static_b, score_b, build_result_b, security_result_b, before_path)
 
     console.rule("[bold green]▶  AFTER[/bold green]")
-    print_report(static_a, score_a, build_result_a, after_path)
+    print_report(static_a, score_a, build_result_a, security_result_a, after_path)
 
     # ── 비교 요약 ────────────────────────────────────────────────
     diff = score_a.score - score_b.score
@@ -62,6 +65,7 @@ def print_report(
     static: StaticAnalysisResult,
     score_result: ScoreResult,
     build_result: BuildResult | None,
+    security_result: SecurityScanResult | None,
     file_path: str,
 ) -> None:
     # ── 헤더 ────────────────────────────────────────────────────
@@ -129,10 +133,34 @@ def print_report(
             build_text = f"[bold]빌드:[/bold] [red]실패[/red]\n{build_result.error_message or ''}"
         console.print(Panel(build_text, title="[bold cyan]🔨 빌드 결과[/bold cyan]", expand=True))
 
+    if security_result is not None:
+        if security_result.success and security_result.summary is not None:
+            counts = security_result.summary.severity_counts
+            security_text = (
+                f"[bold]스캔 모드:[/bold] {security_result.mode}\n"
+                f"[bold]대상:[/bold] {security_result.summary.target}\n"
+                f"[bold]총 발견 건수:[/bold] {security_result.summary.total_findings}\n"
+                f"[bold]CRITICAL:[/bold] {counts.get('CRITICAL', 0)}  |  "
+                f"[bold]HIGH:[/bold] {counts.get('HIGH', 0)}  |  "
+                f"[bold]MEDIUM:[/bold] {counts.get('MEDIUM', 0)}  |  "
+                f"[bold]LOW:[/bold] {counts.get('LOW', 0)}"
+            )
+        else:
+            security_text = (
+                f"[bold]보안 스캔:[/bold] [yellow]실패[/yellow]\n"
+                f"{security_result.error_message or ''}"
+            )
+        console.print(Panel(security_text, title="[bold cyan]🛡️ Trivy 결과[/bold cyan]", expand=True))
+
     # ── 최종 점수 ────────────────────────────────────────────────
     grade_color = _GRADE_COLOR.get(score_result.grade, "white")
     score_text = Text(justify="center")
     score_text.append(f"{score_result.score}점", style=f"bold {grade_color} on default")
     score_text.append("  |  ")
     score_text.append(score_result.grade, style=f"bold {grade_color}")
-    console.print(Panel(score_text, title="[bold]최종 점수[/bold]", expand=False))
+    score_panel_text = Text()
+    score_panel_text.append_text(score_text)
+    score_panel_text.append(
+        f"\n정적 -{score_result.static_deduction} / 빌드 -{score_result.build_deduction} / 보안 -{score_result.security_deduction}"
+    )
+    console.print(Panel(score_panel_text, title="[bold]최종 점수[/bold]", expand=False))

--- a/app/reporter/json_report.py
+++ b/app/reporter/json_report.py
@@ -3,6 +3,7 @@ from dataclasses import asdict
 
 from app.analyzer.static_analyzer import StaticAnalysisResult
 from app.analyzer.build_analyzer import BuildResult
+from app.analyzer.security_analyzer import SecurityScanResult
 from app.scorer.calculator import ScoreResult
 
 
@@ -10,26 +11,40 @@ def compare_to_json(
     static_b: StaticAnalysisResult,
     score_b: ScoreResult,
     build_result_b: BuildResult | None,
+    security_result_b: SecurityScanResult | None,
     static_a: StaticAnalysisResult,
     score_a: ScoreResult,
     build_result_a: BuildResult | None,
+    security_result_a: SecurityScanResult | None,
 ) -> str:
     data = {
         "before": {
             "score": score_b.score,
             "grade": score_b.grade,
+            "deductions": {
+                "static": score_b.static_deduction,
+                "build": score_b.build_deduction,
+                "security": score_b.security_deduction,
+            },
             "base_image": static_b.base_image,
             "base_images": static_b.base_images,
             "warnings": [asdict(w) for w in static_b.warnings],
             "build": asdict(build_result_b) if build_result_b is not None else None,
+            "security": asdict(security_result_b) if security_result_b is not None else None,
         },
         "after": {
             "score": score_a.score,
             "grade": score_a.grade,
+            "deductions": {
+                "static": score_a.static_deduction,
+                "build": score_a.build_deduction,
+                "security": score_a.security_deduction,
+            },
             "base_image": static_a.base_image,
             "base_images": static_a.base_images,
             "warnings": [asdict(w) for w in static_a.warnings],
             "build": asdict(build_result_a) if build_result_a is not None else None,
+            "security": asdict(security_result_a) if security_result_a is not None else None,
         },
         "diff": score_a.score - score_b.score,
     }
@@ -40,13 +55,20 @@ def to_json(
     static: StaticAnalysisResult,
     score_result: ScoreResult,
     build_result: BuildResult | None,
+    security_result: SecurityScanResult | None,
 ) -> str:
     data = {
         "score": score_result.score,
         "grade": score_result.grade,
+        "deductions": {
+            "static": score_result.static_deduction,
+            "build": score_result.build_deduction,
+            "security": score_result.security_deduction,
+        },
         "base_image": static.base_image,
         "base_images": static.base_images,
         "warnings": [asdict(w) for w in static.warnings],
         "build": asdict(build_result) if build_result is not None else None,
+        "security": asdict(security_result) if security_result is not None else None,
     }
     return json.dumps(data, ensure_ascii=False, indent=2)

--- a/app/scorer/calculator.py
+++ b/app/scorer/calculator.py
@@ -2,12 +2,16 @@ from dataclasses import dataclass
 
 from app.analyzer.rules.base import Warning
 from app.analyzer.build_analyzer import BuildResult
+from app.analyzer.security_analyzer import SecurityScanResult
 
 
 @dataclass
 class ScoreResult:
     score: int
     grade: str  # "Good" | "Warning" | "Risky"
+    static_deduction: int
+    build_deduction: int
+    security_deduction: int
 
 
 def _image_size_deduction(image_size_mb: float) -> int:
@@ -21,17 +25,37 @@ def _image_size_deduction(image_size_mb: float) -> int:
         return 20
 
 
-def calculate(warnings: list[Warning], build_result: BuildResult | None) -> ScoreResult:
+def _security_deduction(security_result: SecurityScanResult | None) -> int:
+    if security_result is None or not security_result.success or security_result.summary is None:
+        return 0
+
+    counts = security_result.summary.severity_counts
+    deduction = (
+        counts.get("CRITICAL", 0) * 15
+        + counts.get("HIGH", 0) * 8
+        + counts.get("MEDIUM", 0) * 3
+    )
+    return min(deduction, 40)
+
+
+def calculate(
+    warnings: list[Warning],
+    build_result: BuildResult | None,
+    security_result: SecurityScanResult | None = None,
+) -> ScoreResult:
     static_deduction = sum(w.deduction for w in warnings)
 
     build_deduction = 0
     if build_result is not None and build_result.success and build_result.image_size_mb is not None:
         build_deduction = _image_size_deduction(build_result.image_size_mb)
 
-    score = max(0, 100 - static_deduction - build_deduction)
+    security_deduction = _security_deduction(security_result)
+    score = max(0, 100 - static_deduction - build_deduction - security_deduction)
 
     if build_result is not None and not build_result.success:
         grade = "Risky"
+    elif security_result is not None and not security_result.success:
+        grade = "Warning"
     elif score >= 80:
         grade = "Good"
     elif score >= 50:
@@ -39,4 +63,10 @@ def calculate(warnings: list[Warning], build_result: BuildResult | None) -> Scor
     else:
         grade = "Risky"
 
-    return ScoreResult(score=score, grade=grade)
+    return ScoreResult(
+        score=score,
+        grade=grade,
+        static_deduction=static_deduction,
+        build_deduction=build_deduction,
+        security_deduction=security_deduction,
+    )

--- a/docktor
+++ b/docktor
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+
+from main import main
+
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import typer
 
 from app.analyzer.static_analyzer import analyze
 from app.analyzer.build_analyzer import build_and_analyze
+from app.analyzer.security_analyzer import scan_config, scan_image
 from app.scorer.calculator import calculate
 from app.reporter import console as console_reporter
 from app.reporter import json_report
@@ -25,6 +26,7 @@ def _load(path: Path) -> str:
 def analyze_cmd(
     file: Annotated[Path, typer.Option("--file", "-f", help="분석할 Dockerfile 경로")],
     build: Annotated[bool, typer.Option("--build", help="실제 docker build 실행")] = False,
+    trivy: Annotated[bool, typer.Option("--trivy", help="Trivy 보안 스캔 실행")] = False,
     tag: Annotated[Optional[str], typer.Option("--tag", "-t", help="빌드 태그 (예: myapp:test)")] = None,
     format: Annotated[str, typer.Option("--format", help="출력 형식: text | json")] = "text",
 ):
@@ -33,15 +35,25 @@ def analyze_cmd(
     static = analyze(content)
 
     build_result = None
+    security_result = None
     if build:
         build_result = build_and_analyze(content, tag=tag)
+    if trivy:
+        if build_result is not None and build_result.success:
+            image_ref = build_result.tag or build_result.image_id
+            if image_ref is not None:
+                security_result = scan_image(image_ref)
+        elif build:
+            security_result = None
+        else:
+            security_result = scan_config(str(file))
 
-    score_result = calculate(static.warnings, build_result)
+    score_result = calculate(static.warnings, build_result, security_result)
 
     if format == "json":
-        typer.echo(json_report.to_json(static, score_result, build_result))
+        typer.echo(json_report.to_json(static, score_result, build_result, security_result))
     else:
-        console_reporter.print_report(static, score_result, build_result, str(file))
+        console_reporter.print_report(static, score_result, build_result, security_result, str(file))
 
     sys.exit({"Good": 0, "Warning": 1, "Risky": 2}[score_result.grade])
 
@@ -51,6 +63,7 @@ def compare(
     before: Annotated[Path, typer.Option("--before", help="비교 전 Dockerfile 경로")],
     after: Annotated[Path, typer.Option("--after", help="비교 후 Dockerfile 경로")],
     build: Annotated[bool, typer.Option("--build", help="두 Dockerfile 모두 빌드")] = False,
+    trivy: Annotated[bool, typer.Option("--trivy", help="Trivy 보안 스캔 실행")] = False,
     format: Annotated[str, typer.Option("--format", help="출력 형식: text | json")] = "text",
 ):
     """두 Dockerfile의 Before/After 결과를 비교합니다."""
@@ -62,17 +75,55 @@ def compare(
 
     build_result_b = None
     build_result_a = None
+    security_result_b = None
+    security_result_a = None
     if build:
         build_result_b = build_and_analyze(content_b)
         build_result_a = build_and_analyze(content_a)
 
-    score_b = calculate(static_b.warnings, build_result_b)
-    score_a = calculate(static_a.warnings, build_result_a)
+    if trivy:
+        if build:
+            if build_result_b is not None and build_result_b.success:
+                image_ref_b = build_result_b.tag or build_result_b.image_id
+                if image_ref_b is not None:
+                    security_result_b = scan_image(image_ref_b)
+            if build_result_a is not None and build_result_a.success:
+                image_ref_a = build_result_a.tag or build_result_a.image_id
+                if image_ref_a is not None:
+                    security_result_a = scan_image(image_ref_a)
+        else:
+            security_result_b = scan_config(str(before))
+            security_result_a = scan_config(str(after))
+
+    score_b = calculate(static_b.warnings, build_result_b, security_result_b)
+    score_a = calculate(static_a.warnings, build_result_a, security_result_a)
 
     if format == "json":
-        typer.echo(json_report.compare_to_json(static_b, score_b, build_result_b, static_a, score_a, build_result_a))
+        typer.echo(
+            json_report.compare_to_json(
+                static_b,
+                score_b,
+                build_result_b,
+                security_result_b,
+                static_a,
+                score_a,
+                build_result_a,
+                security_result_a,
+            )
+        )
     else:
-        console_reporter.print_compare(static_b, score_b, build_result_b, static_a, score_a, build_result_a, str(before), str(after))
+        console_reporter.print_compare(
+            static_b,
+            score_b,
+            build_result_b,
+            security_result_b,
+            static_a,
+            score_a,
+            build_result_a,
+            security_result_a,
+            str(before),
+            str(after),
+        )
 
     if build_result_a is not None and not build_result_a.success:
         sys.exit(2)

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ from app.reporter import json_report
 
 app = typer.Typer(help="Docktor — Your Dockerfile Doctor", add_completion=False)
 
+
 def _load(path: Path) -> str:
     if not path.exists():
         typer.echo(f"파일을 찾을 수 없습니다: {path}", err=True)
@@ -129,5 +130,9 @@ def compare(
         sys.exit(2)
 
 
-if __name__ == "__main__":
+def main() -> None:
     app()
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+from setuptools import find_packages, setup
+
+
+setup(
+    name="docktor",
+    version="0.1.0",
+    description="Docktor CLI",
+    py_modules=["main"],
+    packages=find_packages(include=["app", "app.*"]),
+    install_requires=[
+        "annotated-doc==0.0.4",
+        "click==8.3.1",
+        "markdown-it-py==4.0.0",
+        "mdurl==0.1.2",
+        "Pygments==2.20.0",
+        "rich==14.3.3",
+        "shellingham==1.5.4",
+        "typer==0.24.1",
+    ],
+    entry_points={
+        "console_scripts": [
+            "docktor=main:main",
+        ]
+    },
+)

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,49 +1,30 @@
-#FROM 존재하지않는이미지:latest
-
-#FROM python:3.11-slim
-#CMD ["python", "--version"]
-
-
-
-#FROM python:3.11
-#RUN pip install pandas numpy matplotlib scikit-learn
-
-
-
-
-# 테스트 Dockerfile
-## 빌드 스테이지
-#FROM node:latest AS builder
-#
-#COPY . .
-#COPY package.json ./
-#
-#RUN npm install
-#RUN npm run build
-#
-## 실행 스테이지
-#FROM node:20-slim
-#
-#WORKDIR /app
-#
-#COPY --from=builder /app/dist ./dist
-#
-#RUN apt-get update && apt-get install -y curl
-#
-#CMD ["node", "dist/app.js"]
-
-
-#FROM node:latest AS builder
-#RUN echo "building..."
-
-#FROM python:3.11-slim AS tester
-#RUN echo "testing..."
-
 #FROM node:20-slim
 #CMD ["node", "--version"]
 
 #FROM python:3.11-slim
 #RUN pip install 존재하지않는패키지
+#CMD ["python", "--version"]
+
+
+#캐시 효율화 테스트용
+#FROM python:3.11-slim
+#COPY . .
+#RUN pip install -r requirements.txt
+#CMD ["python", "--version"]
+
+#보안 이슈 탐지 테스트용
+#FROM python:3.11-slim
+#RUN chmod u+s /bin/bash
+#RUN echo "SECRET_KEY=abc123" > /tmp/.env
+#RUN echo "test" > /tmp/config.py && chmod o+w /tmp/config.py
+#CMD ["python", "--version"]
+
+#FROM python:3.11-slim
+#RUN chmod u+s /bin/bash
+#RUN echo "DB_PASSWORD=super_secret" > /tmp/secret.txt
+#RUN rm /tmp/secret.txt
+#RUN echo "SECRET_KEY=abc123" > /tmp/.env
+#RUN echo "test" > /tmp/config.py && chmod o+w /tmp/config.py
 #CMD ["python", "--version"]
 
 
@@ -67,3 +48,19 @@ RUN rm /tmp/secret.txt
 RUN echo "SECRET_KEY=abc123" > /tmp/.env
 RUN echo "test" > /tmp/config.py && chmod o+w /tmp/config.py
 CMD ["python", "--version"]
+
+# 빌드가 오래 걸리지 않도록 네트워크 설치 없이, 오래된 베이스 이미지와
+# Dockerfile misconfiguration만으로 Trivy 결과를 유도하는 샘플입니다.
+
+FROM debian:buster-slim
+
+WORKDIR /app
+
+COPY . .
+ADD dummy.txt /tmp/dummy.txt
+
+ENV APP_ENV=dev
+ENV AWS_SECRET_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE
+ENV GITHUB_TOKEN=ghp_exampleexampleexampleexample123456
+
+CMD ["sh", "-c", "sleep 3600"]

--- a/test/Dockerfile.config
+++ b/test/Dockerfile.config
@@ -1,0 +1,7 @@
+FROM alpine:3.17
+
+WORKDIR /app
+
+ADD dummy.txt /app/dummy.txt
+
+CMD ["sh", "-c", "sleep 3600"]


### PR DESCRIPTION
## ✍🏻 Description
- Dockerfile 분석 결과에 Trivy 보안 스캔을 연동
- config/image 스캔 결과 점수에 반영
- `docktor` 실행 진입점을 마련

## 🛠️ Changes
- `--trivy` 옵션으로 `trivy config` / `trivy image`를 실행하도록 연동
- Trivy 미설치 시 운영체제별 설치 안내 메시지 추가
- `Misconfigurations` 배열까지 집계하도록 config 결과 파싱 보강
- build analyzer의 베이스 이미지 추출을 Dockerfile 파서 기준으로 수정
- `test/Dockerfile`, `test/Dockerfile.config` 추가 및 정리
- `docktor` 실행 스크립트와 엔트리 함수 추가

## 📸 Result
- `docktor analyze --file test/Dockerfile --build --trivy -t docktor:test`
<img width="1659" height="722" alt="Screenshot 2026-04-05 at 22 50 54" src="https://github.com/user-attachments/assets/78348579-3512-416c-b8c5-50e427762f05" />
<img width="1654" height="778" alt="Screenshot 2026-04-05 at 22 56 14" src="https://github.com/user-attachments/assets/e723de9e-fd14-4f4a-bdd0-26c7cb0683de" />

## 🔗 Issue
- close #44 

## 👀 Review Requirements
-